### PR TITLE
Mark implicit any types explicitely

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rawmodel",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Strongly-typed JavaScript object with support for validation and error handling.",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -16,8 +16,8 @@ export interface FieldRecipe {
   fakeValue?: any;
   validate?: ValidatorRecipe[];
   handle?: HandlerRecipe[];
-  validators?: {[name: string]: (v?, r?: ValidatorRecipe) => boolean | Promise<boolean>};
-  handlers?: {[name: string]: (v?, r?: HandlerRecipe) => boolean | Promise<boolean>};
+  validators?: {[name: string]: (v? : any, r?: ValidatorRecipe) => boolean | Promise<boolean>};
+  handlers?: {[name: string]: (v? : any, r?: HandlerRecipe) => boolean | Promise<boolean>};
   owner?: Model;
   failFast?: boolean;
   serializable?: boolean;

--- a/src/models.ts
+++ b/src/models.ts
@@ -38,8 +38,8 @@ export interface ModelRecipe {
 export abstract class Model {
   protected _fields: {[name: string]: Field}; // model fields
   protected _types: {[key: string]: (v?) => any}; // custom data types
-  protected _validators: {[key: string]: (v?, r?: ValidatorRecipe) => boolean | Promise<boolean>}; // custom validators
-  protected _handlers: {[key: string]: (v?, r?: HandlerRecipe) => boolean | Promise<boolean>}; // custom validators
+  protected _validators: {[key: string]: (v? : any, r?: ValidatorRecipe) => boolean | Promise<boolean>}; // custom validators
+  protected _handlers: {[key: string]: (v? : any, r?: HandlerRecipe) => boolean | Promise<boolean>}; // custom validators
   protected _failFast: boolean; // stop validating/handling on first error
   readonly root: Model;
   public parent: Model;
@@ -171,7 +171,7 @@ export abstract class Model {
   * Defines a new custom data type.
   */
 
-  public defineType (name: string, converter: (v?) => any): void {
+  public defineType (name: string, converter: (v? : any) => any): void {
     this._types[name] = converter;
   }
 
@@ -179,7 +179,7 @@ export abstract class Model {
   * Defines a new custom validator.
   */
 
-  public defineValidator (name: string, handler: (v?, r?: ValidatorRecipe) => boolean | Promise<boolean>): void {
+  public defineValidator (name: string, handler: (v? : any, r?: ValidatorRecipe) => boolean | Promise<boolean>): void {
     this._validators[name] = handler;
   }
 
@@ -187,7 +187,7 @@ export abstract class Model {
   * Defines a new custom validator.
   */
 
-  public defineHandler (name: string, handler: (e?, r?: HandlerRecipe) => boolean | Promise<boolean>): void {
+  public defineHandler (name: string, handler: (e? : any, r?: HandlerRecipe) => boolean | Promise<boolean>): void {
     this._handlers[name] = handler;
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es3",
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "removeComments": true,
     "sourceMap": true,
     "outDir": "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es3",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "removeComments": true,
     "sourceMap": true,
     "outDir": "dist",


### PR DESCRIPTION
… to play nice with consumers using the `noImplicitAny` compiler option without the `skipLibCheck` compiler option.

Rationale: we're using `noImplicitAny` throughout our codebase, as I'm sure many ts based projects prefer to do. Unless the `skipLibCheck` compiler option is set as well, the build fails with

```

 ERROR  Failed to compile with 8 errors                                                                         19:05:51

 error  in node_modules\rawmodel\dist\src\fields.d.ts

(13,26): error TS7006: Parameter 'v' implicitly has an 'any' type.

 error  in node_modules\rawmodel\dist\src\fields.d.ts

(16,26): error TS7006: Parameter 'v' implicitly has an 'any' type.

 error  in node_modules\rawmodel\dist\src\models.d.ts

(21,25): error TS7006: Parameter 'v' implicitly has an 'any' type.

 error  in node_modules\rawmodel\dist\src\models.d.ts

(24,25): error TS7006: Parameter 'v' implicitly has an 'any' type.

 error  in node_modules\rawmodel\dist\src\models.d.ts

(27,25): error TS7006: Parameter 'v' implicitly has an 'any' type.

 error  in node_modules\rawmodel\dist\src\models.d.ts

(40,42): error TS7006: Parameter 'v' implicitly has an 'any' type.

 error  in node_modules\rawmodel\dist\src\models.d.ts

(41,45): error TS7006: Parameter 'v' implicitly has an 'any' type.

 error  in node_modules\rawmodel\dist\src\models.d.ts

(42,43): error TS7006: Parameter 'e' implicitly has an 'any' type.

```